### PR TITLE
Request to Modify Access Modifiers for Array Functions in DTOs

### DIFF
--- a/src/Dto/SkypeChat/SkypeChatDto.php
+++ b/src/Dto/SkypeChat/SkypeChatDto.php
@@ -19,7 +19,7 @@ class SkypeChatDto
     private $syncState;
 
 
-    private function toArray()
+    public function toArray()
     {
         return [
             'chats' => array_map(function ($chat) {

--- a/src/Dto/SkypeMessage/SkypeMessageDto.php
+++ b/src/Dto/SkypeMessage/SkypeMessageDto.php
@@ -19,7 +19,7 @@ class SkypeMessageDto
     private $syncState;
 
 
-    private function toArray()
+    public function toArray()
     {
         return [
             'messages' => array_map(function ($message) {


### PR DESCRIPTION
I am currently developing a user interface that requires a channel-agnostic approach to integrate various chat services seamlessly. In the process, I identified a need to directly obtain arrays from chat and message interactions, as opposed to DTO instances, to facilitate a more flexible mapping to our internal DTOs.

Upon reviewing the source code of your package, I observed that the requisite functions for array retrieval had initially been implemented, yet their access levels are currently set to private within the DTOs.

I am reaching out to inquire if there is an underlying rationale for maintaining these functions as private. If no specific reasons preclude their exposure, I would like to propose adjusting the access modifiers from private to public.

Thank you for considering this request.