### PR TITLE
Remove var_dump from Connection.php

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -107,7 +107,6 @@ class Connection
             }
 
             $response->getStatusCode();
-            var_dump($response->getStatusCode());
             $response->getContent();
 
             if ($response->getStatusCode() >= 400) {


### PR DESCRIPTION
I noticed a forgotten var_dump call that caused some errors.